### PR TITLE
specify scope for JSON auth

### DIFF
--- a/dnf/artifact-registry.py
+++ b/dnf/artifact-registry.py
@@ -24,6 +24,7 @@ class ArtifactRegistry(dnf.Plugin):
   """DNF Plugin for authenticated access to Google Artifact Registry."""
 
   name = 'artifact-registry'
+  cloud_platform_scope = 'https://www.googleapis.com/auth/cloud-platform'
 
   def __init__(self, base, cli):
     super(ArtifactRegistry, self).__init__(base, cli)
@@ -42,7 +43,7 @@ class ArtifactRegistry(dnf.Plugin):
       if config.has_option('main', 'service_account_json'):
         service_account_json = config.get('main', 'service_account_json')
         return service_account.Credentials.from_service_account_file(
-            service_account_json)
+            service_account_json, scopes=[self.cloud_platform_scope])
       if config.has_option('main', 'service_account_email'):
         service_account_email = config.get('main', 'service_account_email')
         return compute_engine.Credentials(service_account_email)

--- a/yum/artifact-registry.py
+++ b/yum/artifact-registry.py
@@ -22,6 +22,8 @@ from yum.plugins import TYPE_CORE
 requires_api_version = '2.3'
 plugin_type = (TYPE_CORE,)
 
+cloud_platform_scope = 'https://www.googleapis.com/auth/cloud-platform'
+
 
 def prereposetup_hook(conduit):
   credentials = _get_creds(conduit)
@@ -38,7 +40,7 @@ def _get_creds(conduit):
   service_account_json = conduit.confString('main', 'service_account_json', '')
   if service_account_json:
     return service_account.Credentials.from_service_account_file(
-        service_account_json)
+        service_account_json, scopes=[cloud_platform_scope])
   service_account_email = conduit.confString(
       'main', 'service_account_email', '')
   if service_account_email:


### PR DESCRIPTION
specify cloud-platform scope when initializing JSON credentials, leaving all permissions management at the IAM layer
