### PR TITLE
dnf: fix baseurl option lookup

### DIFF
--- a/dnf/artifact-registry.py
+++ b/dnf/artifact-registry.py
@@ -31,10 +31,13 @@ class ArtifactRegistry(dnf.Plugin):
     self.error = False
 
   def config(self):
+    """ Setup http headers to repos with baseurl option containing pkg.dev. """
     for repo in self.base.repos.iter_enabled():
-      opts = dict(repo.cfg.items(repo.id))
+      # We don't have baseurl option so skip it earlier.
+      if not hasattr(repo, 'baseurl'):
+        continue
       # We stop checking if an error has been flagged.
-      if 'pkg.dev' in opts.get('baseurl', '') and not self.error:
+      if 'pkg.dev' in repo.baseurl and not self.error:
         self._add_headers(repo)
 
   def _add_headers(self, repo):


### PR DESCRIPTION
Don't rely on config's items lookup but use the already processed options present within repo object.