### PR TITLE
dnf: fix broken authorization for our gcp repositories

### DIFF
--- a/dnf/artifact-registry.py
+++ b/dnf/artifact-registry.py
@@ -37,7 +37,7 @@ class ArtifactRegistry(dnf.Plugin):
       if not hasattr(repo, 'baseurl'):
         continue
       # We stop checking if an error has been flagged.
-      if 'pkg.dev' in repo.baseurl and not self.error:
+      if 'pkg.dev' in str(repo.baseurl) and not self.error:
         self._add_headers(repo)
 
   def _add_headers(self, repo):


### PR DESCRIPTION
repo.baseurl is not an actual string but a libdnf.module.VectorString and current implementation introduced with eef11a705a3318c7730c19b5dde6866a0296589c actually considers it as string. This patch makes sure to cast it to string before comparison.