### PR TITLE
Prevent yum+dnf plugins from forwarding tokens without SSL.

### DIFF
--- a/dnf/artifact-registry.py
+++ b/dnf/artifact-registry.py
@@ -37,7 +37,8 @@ class ArtifactRegistry(dnf.Plugin):
       if not hasattr(repo, 'baseurl'):
         continue
       # We stop checking if an error has been flagged.
-      if 'pkg.dev' in str(repo.baseurl) and not self.error:
+      baseurl = str(repo.baseurl)
+      if baseurl.startswith('https://') and '-yum.pkg.dev/' in baseurl and not self.error:
         self._add_headers(repo)
 
   def _add_headers(self, repo):

--- a/dnf/artifact-registry.py
+++ b/dnf/artifact-registry.py
@@ -40,6 +40,7 @@ class ArtifactRegistry(dnf.Plugin):
         # We stop checking if an error has been flagged.
         if baseurl.startswith('https://') and '-yum.pkg.dev/' in baseurl and not self.error:
           self._add_headers(repo)
+          break  # Don't add more than one Authorization header.
 
   def _add_headers(self, repo):
     token = self._get_token()

--- a/dnf/artifact-registry.py
+++ b/dnf/artifact-registry.py
@@ -36,10 +36,10 @@ class ArtifactRegistry(dnf.Plugin):
       # We don't have baseurl option so skip it earlier.
       if not hasattr(repo, 'baseurl'):
         continue
-      # We stop checking if an error has been flagged.
-      baseurl = str(repo.baseurl)
-      if baseurl.startswith('https://') and '-yum.pkg.dev/' in baseurl and not self.error:
-        self._add_headers(repo)
+      for baseurl in repo.baseurl:
+        # We stop checking if an error has been flagged.
+        if baseurl.startswith('https://') and '-yum.pkg.dev/' in baseurl and not self.error:
+          self._add_headers(repo)
 
   def _add_headers(self, repo):
     token = self._get_token()

--- a/yum/artifact-registry.py
+++ b/yum/artifact-registry.py
@@ -28,7 +28,7 @@ def prereposetup_hook(conduit):
     return
   for repo in conduit.getRepos().listEnabled():
     for url in repo.urls:
-      if 'pkg.dev' in url:
+      if 'pkg.dev' in url and url.startswith('https://'):
         _add_headers(token, repo)
         break  # Stop looking at URLs
 


### PR DESCRIPTION
This change is in preparation of Artifact Registry supporting plain HTTP (no SSL) access under certain circumstances. Without this change, an eavesdropper might steal a token if a user has misconfigured their yum.conf file; this change will ensure that the plugin only activates for HTTPS connections.