### PR TITLE
Add support for forcing AR auth for a repo.

### DIFF
--- a/dnf/artifact-registry.py
+++ b/dnf/artifact-registry.py
@@ -36,6 +36,11 @@ class ArtifactRegistry(dnf.Plugin):
       # We don't have baseurl option so skip it earlier.
       if not hasattr(repo, 'baseurl'):
         continue
+      # Check if the custom 'ar_auth' option is set in the repository's config.
+      if repo.cfg.getboolean(repo.id, 'ar_auth', fallback=False):
+        self._add_headers(repo)
+        break  # Don't add more than one Authorization header.
+      # Check if any repo urls are for Artifact Registry.
       for baseurl in repo.baseurl:
         # We stop checking if an error has been flagged.
         if baseurl.startswith('https://') and '-yum.pkg.dev/' in baseurl and not self.error:

--- a/yum/artifact-registry.py
+++ b/yum/artifact-registry.py
@@ -27,6 +27,11 @@ def prereposetup_hook(conduit):
   if not token:
     return
   for repo in conduit.getRepos().listEnabled():
+    # Check if the custom 'ar_auth' option is set in the repository's config.
+    if repo.cfg.getboolean(repo.id, 'ar_auth', fallback=False):
+      _add_headers(token, repo)
+      break  # Stop looking at URLs
+    # Check if any repo urls are for Artifact Registry.
     for url in repo.urls:
       if 'pkg.dev' in url and url.startswith('https://'):
         _add_headers(token, repo)


### PR DESCRIPTION
An Artifact Registry auth bearer token will always be added if the repository config sets `ar_auth=1`